### PR TITLE
Get case fees from recently modified Cases

### DIFF
--- a/cityworks_puller/main.py
+++ b/cityworks_puller/main.py
@@ -28,8 +28,8 @@ def run(config):
         raise Exception("Unable to convert number of months to integer")
 
     if report_name == 'Cases':
-        case_object_ids = cityworks.search_cases(token, months_to_include)
-        out_data = cityworks.get_cases_by_ids(token, case_object_ids)
+        case_object_ids = cityworks.search_cases(token)
+        out_data = cityworks.get_cases_by_ids(token, case_object_ids, months_to_include)
     elif report_name == 'Inspections':
         inspection_ids = cityworks.search_inspections(token, months_to_include)
         out_data = cityworks.get_inspections_by_ids(token, inspection_ids)
@@ -40,8 +40,8 @@ def run(config):
         request_ids = cityworks.search_requests(token, months_to_include)
         out_data = cityworks.get_requests_by_ids(token, request_ids)
     elif report_name == 'Case Fees':
-        case_object_ids = cityworks.search_cases(token, months_to_include)
-        out_data = cityworks.get_case_fees_by_id(token, case_object_ids)
+        recent_case_ids = cityworks.get_recent_case_ids(token, months_to_include)
+        out_data = cityworks.get_case_fees_by_id(token, recent_case_ids)
     elif report_name == 'Inspection Questions': 
         inspection_ids = cityworks.search_inspections(token, months_to_include)
         out_data = cityworks.get_inspection_questions_by_ids(token, inspection_ids)


### PR DESCRIPTION
We were limiting the cases we were getting from cityworks by the date entered argument in the api call. This meant we weren't getting updates from cases that were years old but still getting modified. There is no date modified argument on the api endpoint.

We are now getting all cases since there aren't so many that it is overwhelming to pull all every time. This is not the case for case fees though so we are only getting the case ids for cases that were modified in the past x months and using those ids to get the case fees (instead of all cases).