### PR TITLE
Fix work orders puller

### DIFF
--- a/cityworks_puller/cityworks.py
+++ b/cityworks_puller/cityworks.py
@@ -279,3 +279,33 @@ class Cityworks:
         
         logging.info(f"Total work orders retrieved: {len(all_work_orders)}")
         return all_work_orders
+
+    def get_work_orders_last_ten_years(self, token):
+        url = f"{self.base_url}/Ams/WorkOrder/Search"
+        end_date = date.today()
+        start_date = end_date - relativedelta(years=10)
+        all_work_orders = []
+        
+        current_start = start_date
+        while current_start < end_date:
+            current_end = min(current_start + relativedelta(days=7), end_date)
+            
+            date_filter = {
+                "InitiateDateBegin": current_start.strftime("%Y-%m-%d"),
+                "InitiateDateEnd": current_end.strftime("%Y-%m-%d")
+            }
+            
+            payload = {
+                "token": token,
+                "data": json.dumps(date_filter)
+            }
+            
+            response = self.make_api_call("GET", url, payload)
+            if response["Value"]:
+                all_work_orders.extend(response["Value"])
+                logging.info(f"Retrieved work orders from {current_start} to {current_end}")
+            
+            current_start = current_end
+        
+        logging.info(f"Total work orders retrieved: {len(all_work_orders)}")
+        return all_work_orders

--- a/cityworks_puller/main.py
+++ b/cityworks_puller/main.py
@@ -42,8 +42,12 @@ def run(config):
         out_data = cityworks.get_inspections_by_ids(token, inspection_ids)
     # Note: Work orders update but we can't filter by updated date, so we're getting all work orders from the last year
     elif report_name == 'Work Orders':
-        work_order_ids = cityworks.get_work_orders_last_year(token)
-        out_data = cityworks.get_work_orders_by_ids(token, work_order_ids)
+        if days_to_include < 30:
+            work_order_ids = cityworks.get_work_orders_last_year(token)
+            out_data = cityworks.get_work_orders_by_ids(token, work_order_ids)
+        else:
+            work_order_ids = cityworks.get_work_orders_last_ten_years(token)
+            out_data = cityworks.get_work_orders_by_ids(token, work_order_ids)
     elif report_name == 'Requests':
         request_ids = cityworks.search_requests(token, days_to_include, report_filter)
         out_data = cityworks.get_requests_by_ids(token, request_ids)


### PR DESCRIPTION
Add yearly pull and historic pull bc we can't filter queries based on updated date, so 30 day pulls were missing old orders that updated. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds methods to pull work orders from the last year and ten years in `cityworks.py` and updates `main.py` to use these methods for improved data retrieval.
> 
>   - **Behavior**:
>     - Adds `get_work_orders_last_year()` and `get_work_orders_last_ten_years()` in `cityworks.py` to pull work orders for the last year and last ten years, respectively.
>     - Modifies `run()` in `main.py` to use new methods for work orders when `days_to_include` is less than 30.
>   - **Logging**:
>     - Adds logging for time taken to retrieve objects in `get_object_by_ids()` in `cityworks.py`.
>   - **Misc**:
>     - Adds `search_all_work_orders()` in `cityworks.py` for retrieving all work orders without date filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fcityworks_puller&utm_source=github&utm_medium=referral)<sup> for c7b8a4e1671b26b6c3db6bceb4359e793b51c393. You can [customize](https://app.ellipsis.dev/tolemi-inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->