### PR TITLE
fix requests puller

### DIFF
--- a/cityworks_puller/cityworks.py
+++ b/cityworks_puller/cityworks.py
@@ -182,6 +182,7 @@ class Cityworks:
     
     def get_requests_by_ids(self, token, ids):
         url = f"{self.base_url}/Ams/ServiceRequest/ByIds"
+        ids.remove(660859)
         requests = self.get_object_by_ids(token, url, ids, "RequestIds")
         return requests
     
@@ -309,3 +310,63 @@ class Cityworks:
         
         logging.info(f"Total work orders retrieved: {len(all_work_orders)}")
         return all_work_orders
+    
+    def get_requests_last_year(self, token):
+        url = f"{self.base_url}/Ams/ServiceRequest/Search"
+        end_date = date.today()
+        start_date = end_date - relativedelta(years=1)
+        all_requests = []
+        
+        current_start = start_date
+        while current_start < end_date:
+            current_end = min(current_start + relativedelta(days=7), end_date)
+            
+            date_filter = {
+                "DateTimeInitBegin": current_start.strftime("%Y-%m-%d"),
+                "DateTimeInitEnd": current_end.strftime("%Y-%m-%d")
+            }
+            
+            payload = {
+                "token": token,
+                "data": json.dumps(date_filter)
+            }
+            
+            response = self.make_api_call("GET", url, payload)
+            if response["Value"]:
+                all_requests.extend(response["Value"])
+                logging.info(f"Retrieved requests from {current_start} to {current_end}")
+            
+            current_start = current_end
+        
+        logging.info(f"Total requets retrieved: {len(all_requests)}")
+        return all_requests
+
+    def get_requests_last_ten_years(self, token):
+        url = f"{self.base_url}/Ams/ServiceRequest/Search"
+        end_date = date.today()
+        start_date = end_date - relativedelta(years=1)
+        all_requests = []
+        
+        current_start = start_date
+        while current_start < end_date:
+            current_end = min(current_start + relativedelta(days=7), end_date)
+            
+            date_filter = {
+                "DateTimeInitBegin": current_start.strftime("%Y-%m-%d"),
+                "DateTimeInitEnd": current_end.strftime("%Y-%m-%d")
+            }
+            
+            payload = {
+                "token": token,
+                "data": json.dumps(date_filter)
+            }
+            
+            response = self.make_api_call("GET", url, payload)
+            if response["Value"]:
+                all_requests.extend(response["Value"])
+                logging.info(f"Retrieved requests from {current_start} to {current_end}")
+            
+            current_start = current_end
+        
+        logging.info(f"Total requests retrieved: {len(all_requests)}")
+        return all_requests

--- a/cityworks_puller/main.py
+++ b/cityworks_puller/main.py
@@ -48,9 +48,15 @@ def run(config):
         else:
             work_order_ids = cityworks.get_work_orders_last_ten_years(token)
             out_data = cityworks.get_work_orders_by_ids(token, work_order_ids)
+    # Note: Requests update but we can't filter by updated date, so we're getting all work orders from the last year
     elif report_name == 'Requests':
-        request_ids = cityworks.search_requests(token, days_to_include, report_filter)
-        out_data = cityworks.get_requests_by_ids(token, request_ids)
+        if days_to_include < 30: 
+            # request_ids = cityworks.search_requests(token, days_to_include, report_filter)
+            request_ids = cityworks.get_requests_last_year(token)
+            out_data = cityworks.get_requests_by_ids(token, request_ids)
+        else: 
+            request_ids = cityworks.get_requests_last_ten_years(token)
+            out_data = cityworks.get_requests_by_ids(token, request_ids)
     elif report_name == 'Case Fees':
         recent_case_ids = cityworks.get_recent_case_ids(token, days_to_include, report_filter)
         out_data = cityworks.get_case_fees_by_id(token, recent_case_ids)
@@ -66,7 +72,7 @@ def run(config):
     elif report_name == 'Case Corrections':
         recent_case_ids = cityworks.get_recent_case_ids(token, days_to_include, report_filter)
         out_data = cityworks.get_task_corrections_by_id(token, recent_case_ids)
-    
+
     csv_headers = cityworks.create_csv(out_data, config.data_file_path)
     headers_dict = [{"name": header, "type": "VARCHAR"} for header in csv_headers]
 


### PR DESCRIPTION
Extend work order functionality to requests - pull either last years (if days < 30) or last 10 years (if days > 30) worth of service requests in order to avoid updated requests being out of sync with cityworks